### PR TITLE
Makes the README a symlink to orgpapers.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-Reproducible Research Papers using Org-mode and R: A Guide
-========
-
-This guide introduces an open-source toolkit for writing research papers and monographs. The main features of this toolkit centered around Emacs and Org-mode are: 1) embedding R code in the document that allows for statistical results to be revised and reproduced, 2) bibliographic citations from an integrated database, 3) formatting using well defined styles with minimal markup, 4) support for production of final output as pdf, odt, docx, html and many other formats.
-
-See the file [orgpapers.org](https://github.com/vikasrawal/orgpaper/blob/master/orgpapers.org) for the main text of the guide.
-

--- a/README.org
+++ b/README.org
@@ -1,0 +1,1 @@
+orgpapers.org


### PR DESCRIPTION
This way the reader will instantly be redirected to the main body text rather than having to navigate to it manually. 